### PR TITLE
feat: set white background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -12,13 +12,6 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
   background: var(--background);
   color: var(--foreground);


### PR DESCRIPTION
## Summary
- remove dark mode background override so pages always use a white background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f5876fd248327ba3fa588920bb435