### PR TITLE
feat: support tree and list views for posts

### DIFF
--- a/app/02-community-board/[pref]/page.tsx
+++ b/app/02-community-board/[pref]/page.tsx
@@ -24,6 +24,7 @@ export default function PostsListPage() {
   const decodedPref = decodeURIComponent(pref)
   const router = useRouter()
   const [posts, setPosts] = useState<Post[]>([])
+  const [viewMode, setViewMode] = useState<'list' | 'tree'>('list')
 
   useEffect(() => {
     supabase
@@ -50,7 +51,27 @@ export default function PostsListPage() {
           {decodedPref} の掲示板
         </h1>
 
-        <div className="flex justify-end mb-6">
+        <div className="flex justify-end mb-6 space-x-2">
+          <button
+            onClick={() => setViewMode('list')}
+            className={`px-4 py-2 rounded-lg ${
+              viewMode === 'list'
+                ? 'bg-blue-500 hover:bg-blue-600 text-white'
+                : 'bg-gray-200 text-gray-700'
+            }`}
+          >
+            一覧表示
+          </button>
+          <button
+            onClick={() => setViewMode('tree')}
+            className={`px-4 py-2 rounded-lg ${
+              viewMode === 'tree'
+                ? 'bg-blue-500 hover:bg-blue-600 text-white'
+                : 'bg-gray-200 text-gray-700'
+            }`}
+          >
+            ツリー表示
+          </button>
           <button
             onClick={() => router.push(`/02-community-board/${pref}/01-new`)}
             className="px-5 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg shadow transition"
@@ -64,7 +85,7 @@ export default function PostsListPage() {
             まだ投稿がありません。<br/>
             ぜひ最初の投稿をしてみましょう！
           </p>
-        ) : (
+        ) : viewMode === 'list' ? (
           <ul className="space-y-6">
             {posts.map((post) => (
               <li
@@ -109,6 +130,24 @@ export default function PostsListPage() {
                     削除
                   </button>
                 </div>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <ul className="space-y-4">
+            {posts.map((post) => (
+              <li
+                key={post.id}
+                className="border border-gray-200 rounded-lg p-4 bg-gray-50 hover:bg-gray-100 transition"
+              >
+                <button
+                  onClick={() =>
+                    router.push(`/02-community-board/${pref}/post/${post.id}`)
+                  }
+                  className="text-left w-full text-blue-800 hover:underline"
+                >
+                  {post.title}
+                </button>
               </li>
             ))}
           </ul>

--- a/app/02-community-board/[pref]/post/[id]/page.tsx
+++ b/app/02-community-board/[pref]/post/[id]/page.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { useParams, useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { supabase } from '../../../../../lib/supabaseClient'
+
+type Post = {
+  id: number
+  prefecture: string
+  name: string | null
+  profile: string | null
+  title: string
+  content: string
+  delete_key: string
+  insert_datetime: string
+  insert_program: string
+  update_datetime: string
+  update_program: string
+}
+
+export default function PostDetailPage() {
+  const { pref, id } = useParams() as { pref: string; id: string }
+  const router = useRouter()
+  const [post, setPost] = useState<Post | null>(null)
+
+  useEffect(() => {
+    supabase
+      .from('TBL_T_POSTS')
+      .select('*')
+      .eq('id', Number(id))
+      .single()
+      .then(({ data }) => {
+        setPost(data ?? null)
+      })
+  }, [id])
+
+  if (!post) {
+    return (
+      <div className="max-w-4xl mx-auto py-8">
+        <div className="bg-white shadow-lg rounded-xl p-8 text-center">読み込み中...</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto py-8">
+      <div className="bg-white shadow-lg rounded-xl p-8">
+        <button
+          onClick={() => router.push(`/02-community-board/${pref}`)}
+          className="text-blue-500 hover:text-blue-700 mb-4 flex items-center"
+        >
+          ← 投稿一覧に戻る
+        </button>
+
+        <h1 className="text-2xl font-bold text-blue-700 mb-4">{post.title}</h1>
+        <div className="text-sm text-gray-600 mb-4">
+          {post.name || '匿名'} &middot; {new Date(post.insert_datetime).toLocaleString()}
+        </div>
+        {post.profile && (
+          <p className="italic text-gray-700 mb-4">プロフィール: {post.profile}</p>
+        )}
+        <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add view mode toggle to posts list page to switch between list and tree display
- create post detail page and link to it from tree view

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f5bf71e708327a2131f7903eb132a