### PR TITLE
Add contact fields to new posts

### DIFF
--- a/app/02-community-board/[pref]/01-new/page.tsx
+++ b/app/02-community-board/[pref]/01-new/page.tsx
@@ -14,6 +14,9 @@ export default function NewPostPage() {
   const [profile, setProfile] = useState('');
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
+  const [lineId, setLineId] = useState('');
+  const [kakaoId, setKakaoId] = useState('');
+  const [free, setFree] = useState('');
   const [deleteKey, setDeleteKey] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -31,6 +34,9 @@ export default function NewPostPage() {
         profile: profile || null,
         title,
         content,
+        line_id: lineId || null,
+        kakao_id: kakaoId || null,
+        free: free || null,
         delete_key: deleteKey,
         insert_program: 'frontend',
       });
@@ -95,6 +101,35 @@ export default function NewPostPage() {
           value={content}
           onChange={(e) => setContent(e.target.value)}
           required
+          className="w-full p-2 border rounded h-24"
+        />
+        <label htmlFor='lineId' className='block mb-1 font-medium text-black'>
+          LINE ID
+        </label>
+        <input
+          type="text"
+          placeholder="line123"
+          value={lineId}
+          onChange={(e) => setLineId(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <label htmlFor='kakaoId' className='block mb-1 font-medium text-black'>
+          Kakao ID
+        </label>
+        <input
+          type="text"
+          placeholder="kakao123"
+          value={kakaoId}
+          onChange={(e) => setKakaoId(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <label htmlFor='free' className='block mb-1 font-medium text-black'>
+          フリーテキスト
+        </label>
+        <textarea
+          placeholder="自由にご記入ください"
+          value={free}
+          onChange={(e) => setFree(e.target.value)}
           className="w-full p-2 border rounded h-24"
         />
         <label htmlFor='email' className='block mb-1 font-medium text-black'>

--- a/app/02-community-board/[pref]/page.tsx
+++ b/app/02-community-board/[pref]/page.tsx
@@ -12,6 +12,9 @@ type Post = {
   profile: string | null
   title: string
   content: string
+  line_id: string | null
+  kakao_id: string | null
+  free: string | null
   delete_key: string
   insert_datetime: string
   insert_program: string

--- a/app/02-community-board/[pref]/post/[id]/page.tsx
+++ b/app/02-community-board/[pref]/post/[id]/page.tsx
@@ -11,6 +11,9 @@ type Post = {
   profile: string | null
   title: string
   content: string
+  line_id: string | null
+  kakao_id: string | null
+  free: string | null
   delete_key: string
   insert_datetime: string
   insert_program: string
@@ -59,7 +62,16 @@ export default function PostDetailPage() {
         {post.profile && (
           <p className="italic text-gray-700 mb-4">プロフィール: {post.profile}</p>
         )}
-        <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>
+        <p className="text-gray-800 whitespace-pre-wrap mb-4">{post.content}</p>
+        {post.line_id && (
+          <p className="text-gray-800 mb-1">LINE ID: {post.line_id}</p>
+        )}
+        {post.kakao_id && (
+          <p className="text-gray-800 mb-1">Kakao ID: {post.kakao_id}</p>
+        )}
+        {post.free && (
+          <p className="text-gray-800 whitespace-pre-wrap">{post.free}</p>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- allow posts to capture LINE ID, Kakao ID, and an optional free-text note
- persist new contact fields in `TBL_T_POSTS`
- show contact details on individual post pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f601f43208327b6fc645d213b189c