### PR TITLE
Add sender email field and validation

### DIFF
--- a/app/02-community-board/[pref]/03-mail/[id]/page.tsx
+++ b/app/02-community-board/[pref]/03-mail/[id]/page.tsx
@@ -16,13 +16,13 @@ function maskEmail(email: string): string {
 }
 
 export default function MailPage() {
-  const { pref, id } = useParams() as { pref: string; id: string }
-  const decodedPref = decodeURIComponent(pref)
+  const { id } = useParams() as { id: string }
   const postId = Number(id)
   const router = useRouter()
 
   const [maskedEmail, setMaskedEmail] = useState('Loading...')
   const [realEmail, setRealEmail]     = useState('')
+  const [fromEmail, setFromEmail]     = useState('')
   const [subject, setSubject]         = useState('')
   const [body, setBody]               = useState('')
   const [errorMsg, setErrorMsg]       = useState('')
@@ -48,6 +48,13 @@ export default function MailPage() {
     e.preventDefault()
     setErrorMsg('')
 
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+    if (!emailRegex.test(fromEmail)) {
+      setErrorMsg('送信元のメールアドレスを正しく入力してください')
+      return
+    }
+
     if (!subject.trim() || !body.trim()) {
       setErrorMsg('件名と本文は必須です')
       return
@@ -57,7 +64,7 @@ export default function MailPage() {
       const res = await fetch('/api/send-email', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ to: realEmail, subject, body })
+        body: JSON.stringify({ from: fromEmail, to: realEmail, subject, body })
       })
       const json = await res.json()
       if (!res.ok) throw new Error(json.error || '送信に失敗しました')
@@ -76,7 +83,7 @@ export default function MailPage() {
   return (
     <main className="p-6 max-w-md mx-auto bg-white shadow-lg rounded-xl">
       <h1 className="text-2xl font-semibold mb-4">
-        メール送信 （{decodedPref}）
+        メール送信
       </h1>
       <form onSubmit={handleSend} className="space-y-4">
         <div>
@@ -84,6 +91,20 @@ export default function MailPage() {
             宛先（匿名表示）
           </label>
           <p className="mt-1 text-gray-900">{maskedEmail}</p>
+        </div>
+
+        <div>
+          <label htmlFor="from" className="block text-sm font-medium text-gray-700">
+            あなたのメールアドレス *
+          </label>
+          <input
+            id="from"
+            type="email"
+            value={fromEmail}
+            onChange={(e) => { setFromEmail(e.target.value); setErrorMsg('') }}
+            className="mt-1 w-full p-2 border rounded"
+            required
+          />
         </div>
 
         <div>

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -4,11 +4,11 @@ import { NextResponse } from 'next/server'
 import { sendMail } from '../../../lib/mailClient'
 
 export async function POST(request: Request) {
-  const { to, subject, body } = await request.json()
-  console.log('[send-email]', { to, subject, body })
+  const { from, to, subject, body } = await request.json()
+  console.log('[send-email]', { from, to, subject, body })
 
   try {
-    await sendMail({ to, subject, body })
+    await sendMail({ from, to, subject, body })
     return NextResponse.json({ success: true })
   } catch (err: unknown) {
     console.error('Mail send error:', err)

--- a/lib/mailClient.ts
+++ b/lib/mailClient.ts
@@ -1,17 +1,17 @@
 // lib/mailClient.ts
 
-// lib/mailClient.ts
 console.log('📨 MAILERSEND_API_KEY:', process.env.MAILERSEND_API_KEY?.slice(0,10) + '…')
 
 import { MailerSend, EmailParams, Sender, Recipient } from 'mailersend'
 
 type SendParams = {
+  from: string
   to: string
   subject: string
   body: string
 }
 
-export async function sendMail({ to, subject, body }: SendParams) {
+export async function sendMail({ from, to, subject, body }: SendParams) {
   if (process.env.MAIL_PROVIDER !== 'mailersend') {
     throw new Error('MAIL_PROVIDER が mailersend に設定されていません')
   }
@@ -20,21 +20,26 @@ export async function sendMail({ to, subject, body }: SendParams) {
     apiKey: process.env.MAILERSEND_API_KEY!,
   })
 
-  // 送信元
-  const from = new Sender(
+  // 送信元（システム既定）
+  const sender = new Sender(
     process.env.MAILERSEND_FROM_EMAIL!,
-    process.env.MAILERSEND_FROM_NAME!
+    process.env.MAILERSEND_FROM_NAME!,
   )
 
   // 宛先
   const toList = [ new Recipient(to) ]
 
+  // Reply-To にユーザー入力のメールアドレスを設定
+  const replyTo = new Recipient(from)
+
   const emailParams = new EmailParams()
-    .setFrom(from)
+    .setFrom(sender)
     .setTo(toList)
     .setSubject(subject)
     .setText(body)
+    .setReplyTo(replyTo)
 
   // ← 注意：ここを .email.send に変える
   await ms.email.send(emailParams)
 }
+


### PR DESCRIPTION
## Summary
- drop prefecture name from mail header
- add sender email input with validation and reply-to handling

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f6203a8d48327aeb28d0702fc118a