### PR TITLE
Use full width for main content

### DIFF
--- a/app/01-choice-prefectures/page.tsx
+++ b/app/01-choice-prefectures/page.tsx
@@ -53,44 +53,42 @@ export default function ChoicePrefecturesPage() {
   const router = useRouter();
 
   return (
-    <div className="max-w-4xl mx-auto">
-      <div className="bg-white shadow-lg rounded-xl p-8">
-        <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-blue-700 mb-4">
-            Boys Matching
-          </h1>
-          <p className="text-lg text-gray-700">
-            当サイトはゲイの出会いを目的としています。皆様に素敵な出会いがありますように
-          </p>
-        </div>
-        <h2 className="text-3xl font-bold text-blue-700 mb-8 text-center">
-          都道府県を選択してください
-        </h2>
-
-        {REGIONS.map(region => (
-          <section key={region.name} className="mb-8">
-            <h3 className="text-2xl font-semibold text-blue-600 mb-4">
-              {region.name}
-            </h3>
-            <ul className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4">
-              {region.prefectures.map(pref => (
-                <li key={pref}>
-                  <button
-                    onClick={() =>
-                      router.push(
-                        `/02-community-board/${encodeURIComponent(pref)}`
-                      )
-                    }
-                    className="w-full py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg shadow transition"
-                  >
-                    {pref}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </section>
-        ))}
+    <>
+      <div className="text-center mb-8">
+        <h1 className="text-4xl font-bold text-blue-700 mb-4">
+          Boys Matching
+        </h1>
+        <p className="text-lg text-gray-700">
+          当サイトはゲイの出会いを目的としています。皆様に素敵な出会いがありますように
+        </p>
       </div>
-    </div>
+      <h2 className="text-3xl font-bold text-blue-700 mb-8 text-center">
+        都道府県を選択してください
+      </h2>
+
+      {REGIONS.map(region => (
+        <section key={region.name} className="mb-8">
+          <h3 className="text-2xl font-semibold text-blue-600 mb-4">
+            {region.name}
+          </h3>
+          <ul className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4">
+            {region.prefectures.map(pref => (
+              <li key={pref}>
+                <button
+                  onClick={() =>
+                    router.push(
+                      `/02-community-board/${encodeURIComponent(pref)}`
+                    )
+                  }
+                  className="w-full py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg shadow transition"
+                >
+                  {pref}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </>
   );
 }

--- a/app/02-community-board/[pref]/01-new/page.tsx
+++ b/app/02-community-board/[pref]/01-new/page.tsx
@@ -48,7 +48,7 @@ export default function NewPostPage() {
   };
 
   return (
-    <main className="p-6 max-w-xl mx-auto">
+    <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4 text-black">
         「{decodedPref}」に新規投稿
       </h1>
@@ -159,6 +159,6 @@ export default function NewPostPage() {
           </button>
         </div>
       </form>
-    </main>
+    </div>
   );
 }

--- a/app/02-community-board/[pref]/02-delete/[id]/page.tsx
+++ b/app/02-community-board/[pref]/02-delete/[id]/page.tsx
@@ -32,7 +32,7 @@ export default function DeletePostPage() {
   };
 
   return (
-    <main className="p-6 max-w-md mx-auto bg-white shadow-lg rounded-xl">
+    <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">
         「{decodedPref}」の投稿削除
       </h1>
@@ -65,6 +65,6 @@ export default function DeletePostPage() {
           </button>
         </div>
       </form>
-    </main>
+    </div>
   );
 }

--- a/app/02-community-board/[pref]/03-mail/[id]/page.tsx
+++ b/app/02-community-board/[pref]/03-mail/[id]/page.tsx
@@ -81,7 +81,7 @@ export default function MailPage() {
   }
 
   return (
-    <main className="p-6 max-w-md mx-auto bg-white shadow-lg rounded-xl">
+    <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4">
         メール送信
       </h1>
@@ -153,6 +153,6 @@ export default function MailPage() {
           </button>
         </div>
       </form>
-    </main>
-  )
+    </div>
+  );
 }

--- a/app/02-community-board/[pref]/page.tsx
+++ b/app/02-community-board/[pref]/page.tsx
@@ -41,121 +41,119 @@ export default function PostsListPage() {
   }, [decodedPref])
 
   return (
-    <div className="max-w-4xl mx-auto py-8">
-      <div className="bg-white shadow-lg rounded-xl p-8">
+    <>
+      <button
+        onClick={() => router.push('/01-choice-prefectures')}
+        className="text-blue-500 hover:text-blue-700 mb-4 flex items-center"
+      >
+        ← 都道府県を選び直す
+      </button>
+
+      <h1 className="text-3xl font-bold text-blue-700 mb-6 text-center">
+        {decodedPref} の掲示板
+      </h1>
+
+      <div className="flex justify-end mb-6 space-x-2">
         <button
-          onClick={() => router.push('/01-choice-prefectures')}
-          className="text-blue-500 hover:text-blue-700 mb-4 flex items-center"
+          onClick={() => setViewMode('list')}
+          className={`px-4 py-2 rounded-lg ${
+            viewMode === 'list'
+              ? 'bg-blue-500 hover:bg-blue-600 text-white'
+              : 'bg-gray-200 text-gray-700'
+          }`}
         >
-          ← 都道府県を選び直す
+          一覧表示
         </button>
+        <button
+          onClick={() => setViewMode('tree')}
+          className={`px-4 py-2 rounded-lg ${
+            viewMode === 'tree'
+              ? 'bg-blue-500 hover:bg-blue-600 text-white'
+              : 'bg-gray-200 text-gray-700'
+          }`}
+        >
+          ツリー表示
+        </button>
+        <button
+          onClick={() => router.push(`/02-community-board/${pref}/01-new`)}
+          className="px-5 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg shadow transition"
+        >
+          新規投稿
+        </button>
+      </div>
 
-        <h1 className="text-3xl font-bold text-blue-700 mb-6 text-center">
-          {decodedPref} の掲示板
-        </h1>
-
-        <div className="flex justify-end mb-6 space-x-2">
-          <button
-            onClick={() => setViewMode('list')}
-            className={`px-4 py-2 rounded-lg ${
-              viewMode === 'list'
-                ? 'bg-blue-500 hover:bg-blue-600 text-white'
-                : 'bg-gray-200 text-gray-700'
-            }`}
-          >
-            一覧表示
-          </button>
-          <button
-            onClick={() => setViewMode('tree')}
-            className={`px-4 py-2 rounded-lg ${
-              viewMode === 'tree'
-                ? 'bg-blue-500 hover:bg-blue-600 text-white'
-                : 'bg-gray-200 text-gray-700'
-            }`}
-          >
-            ツリー表示
-          </button>
-          <button
-            onClick={() => router.push(`/02-community-board/${pref}/01-new`)}
-            className="px-5 py-2 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg shadow transition"
-          >
-            新規投稿
-          </button>
-        </div>
-
-        {posts.length === 0 ? (
-          <p className="text-center text-gray-500 py-12">
-            まだ投稿がありません。<br/>
-            ぜひ最初の投稿をしてみましょう！
-          </p>
-        ) : viewMode === 'list' ? (
-          <ul className="space-y-6">
-            {posts.map((post) => (
-              <li
-                key={post.id}
-                className="border border-gray-200 rounded-lg p-6 bg-gray-50 hover:bg-gray-100 transition"
-              >
-                <div className="flex justify-between items-start mb-3">
-                  <h2 className="text-xl font-semibold text-blue-800">
-                    {post.title}
-                  </h2>
-                  <button
-                    onClick={() =>
-                      router.push(`/02-community-board/${pref}/03-mail/${post.id}`)
-                    }
-                    className="text-blue-500 hover:text-blue-700 text-2xl"
-                    aria-label="メール送信"
-                  >
-                    📧
-                  </button>
-                </div>
-
-                <div className="text-sm text-gray-600 mb-4">
-                  {post.name || '匿名'} &middot;{' '}
-                  {new Date(post.insert_datetime).toLocaleString()}
-                </div>
-
-                {post.profile && (
-                  <p className="italic text-gray-700 mb-4">
-                    プロフィール: {post.profile}
-                  </p>
-                )}
-
-                <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>
-
-                <div className="mt-4 flex justify-end">
-                  <button
-                    onClick={() =>
-                      router.push(`/02-community-board/${pref}/02-delete/${post.id}`)
-                    }
-                    className="px-4 py-1 bg-red-500 hover:bg-red-600 text-white rounded-lg"
-                  >
-                    削除
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <ul className="space-y-4">
-            {posts.map((post) => (
-              <li
-                key={post.id}
-                className="border border-gray-200 rounded-lg p-4 bg-gray-50 hover:bg-gray-100 transition"
-              >
+      {posts.length === 0 ? (
+        <p className="text-center text-gray-500 py-12">
+          まだ投稿がありません。<br/>
+          ぜひ最初の投稿をしてみましょう！
+        </p>
+      ) : viewMode === 'list' ? (
+        <ul className="space-y-6">
+          {posts.map((post) => (
+            <li
+              key={post.id}
+              className="border border-gray-200 rounded-lg p-6 bg-gray-50 hover:bg-gray-100 transition"
+            >
+              <div className="flex justify-between items-start mb-3">
+                <h2 className="text-xl font-semibold text-blue-800">
+                  {post.title}
+                </h2>
                 <button
                   onClick={() =>
-                    router.push(`/02-community-board/${pref}/post/${post.id}`)
+                    router.push(`/02-community-board/${pref}/03-mail/${post.id}`)
                   }
-                  className="text-left w-full text-blue-800 hover:underline"
+                  className="text-blue-500 hover:text-blue-700 text-2xl"
+                  aria-label="メール送信"
                 >
-                  {post.title}
+                  📧
                 </button>
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-    </div>
-  )
+              </div>
+
+              <div className="text-sm text-gray-600 mb-4">
+                {post.name || '匿名'} &middot;{' '}
+                {new Date(post.insert_datetime).toLocaleString()}
+              </div>
+
+              {post.profile && (
+                <p className="italic text-gray-700 mb-4">
+                  プロフィール: {post.profile}
+                </p>
+              )}
+
+              <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>
+
+              <div className="mt-4 flex justify-end">
+                <button
+                  onClick={() =>
+                    router.push(`/02-community-board/${pref}/02-delete/${post.id}`)
+                  }
+                  className="px-4 py-1 bg-red-500 hover:bg-red-600 text-white rounded-lg"
+                >
+                  削除
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <ul className="space-y-4">
+          {posts.map((post) => (
+            <li
+              key={post.id}
+              className="border border-gray-200 rounded-lg p-4 bg-gray-50 hover:bg-gray-100 transition"
+            >
+              <button
+                onClick={() =>
+                  router.push(`/02-community-board/${pref}/post/${post.id}`)
+                }
+                className="text-left w-full text-blue-800 hover:underline"
+              >
+                {post.title}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
 }

--- a/app/02-community-board/[pref]/post/[id]/page.tsx
+++ b/app/02-community-board/[pref]/post/[id]/page.tsx
@@ -38,41 +38,35 @@ export default function PostDetailPage() {
   }, [id])
 
   if (!post) {
-    return (
-      <div className="max-w-4xl mx-auto py-8">
-        <div className="bg-white shadow-lg rounded-xl p-8 text-center">読み込み中...</div>
-      </div>
-    )
+    return <div className="py-8 text-center">読み込み中...</div>
   }
 
   return (
-    <div className="max-w-4xl mx-auto py-8">
-      <div className="bg-white shadow-lg rounded-xl p-8">
-        <button
-          onClick={() => router.push(`/02-community-board/${pref}`)}
-          className="text-blue-500 hover:text-blue-700 mb-4 flex items-center"
-        >
-          ← 投稿一覧に戻る
-        </button>
+    <>
+      <button
+        onClick={() => router.push(`/02-community-board/${pref}`)}
+        className="text-blue-500 hover:text-blue-700 mb-4 flex items-center"
+      >
+        ← 投稿一覧に戻る
+      </button>
 
-        <h1 className="text-2xl font-bold text-blue-700 mb-4">{post.title}</h1>
-        <div className="text-sm text-gray-600 mb-4">
-          {post.name || '匿名'} &middot; {new Date(post.insert_datetime).toLocaleString()}
-        </div>
-        {post.profile && (
-          <p className="italic text-gray-700 mb-4">プロフィール: {post.profile}</p>
-        )}
-        <p className="text-gray-800 whitespace-pre-wrap mb-4">{post.content}</p>
-        {post.line_id && (
-          <p className="text-gray-800 mb-1">LINE ID: {post.line_id}</p>
-        )}
-        {post.kakao_id && (
-          <p className="text-gray-800 mb-1">Kakao ID: {post.kakao_id}</p>
-        )}
-        {post.free && (
-          <p className="text-gray-800 whitespace-pre-wrap">{post.free}</p>
-        )}
+      <h1 className="text-2xl font-bold text-blue-700 mb-4">{post.title}</h1>
+      <div className="text-sm text-gray-600 mb-4">
+        {post.name || '匿名'} &middot; {new Date(post.insert_datetime).toLocaleString()}
       </div>
-    </div>
-  )
+      {post.profile && (
+        <p className="italic text-gray-700 mb-4">プロフィール: {post.profile}</p>
+      )}
+      <p className="text-gray-800 whitespace-pre-wrap mb-4">{post.content}</p>
+      {post.line_id && (
+        <p className="text-gray-800 mb-1">LINE ID: {post.line_id}</p>
+      )}
+      {post.kakao_id && (
+        <p className="text-gray-800 mb-1">Kakao ID: {post.kakao_id}</p>
+      )}
+      {post.free && (
+        <p className="text-gray-800 whitespace-pre-wrap">{post.free}</p>
+      )}
+    </>
+  );
 }


### PR DESCRIPTION
## Summary
- Remove max-width wrappers from main pages so content can span the entire central area
- Simplify page layouts by eliminating nested `main` elements

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a034781d188327882fcef2e9430017