### PR TITLE
Remove nested width limits from main content

### DIFF
--- a/app/01-choice-prefectures/page.tsx
+++ b/app/01-choice-prefectures/page.tsx
@@ -53,7 +53,7 @@ export default function ChoicePrefecturesPage() {
   const router = useRouter();
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div>
       <div className="bg-white shadow-lg rounded-xl p-8">
         <div className="text-center mb-8">
           <h1 className="text-4xl font-bold text-blue-700 mb-4">

--- a/app/02-community-board/[pref]/01-new/page.tsx
+++ b/app/02-community-board/[pref]/01-new/page.tsx
@@ -48,7 +48,7 @@ export default function NewPostPage() {
   };
 
   return (
-    <main className="p-6 max-w-xl mx-auto">
+    <div className="p-6">
       <h1 className="text-2xl font-semibold mb-4 text-black">
         「{decodedPref}」に新規投稿
       </h1>
@@ -159,6 +159,6 @@ export default function NewPostPage() {
           </button>
         </div>
       </form>
-    </main>
+    </div>
   );
 }

--- a/app/02-community-board/[pref]/02-delete/[id]/page.tsx
+++ b/app/02-community-board/[pref]/02-delete/[id]/page.tsx
@@ -32,7 +32,7 @@ export default function DeletePostPage() {
   };
 
   return (
-    <main className="p-6 max-w-md mx-auto bg-white shadow-lg rounded-xl">
+    <main className="p-6 bg-white shadow-lg rounded-xl">
       <h1 className="text-2xl font-semibold mb-4">
         「{decodedPref}」の投稿削除
       </h1>

--- a/app/02-community-board/[pref]/03-mail/[id]/page.tsx
+++ b/app/02-community-board/[pref]/03-mail/[id]/page.tsx
@@ -81,7 +81,7 @@ export default function MailPage() {
   }
 
   return (
-    <main className="p-6 max-w-md mx-auto bg-white shadow-lg rounded-xl">
+    <main className="p-6 bg-white shadow-lg rounded-xl">
       <h1 className="text-2xl font-semibold mb-4">
         メール送信
       </h1>

--- a/app/02-community-board/[pref]/page.tsx
+++ b/app/02-community-board/[pref]/page.tsx
@@ -41,7 +41,7 @@ export default function PostsListPage() {
   }, [decodedPref])
 
   return (
-    <div className="max-w-4xl mx-auto py-8">
+    <div className="py-8">
       <div className="bg-white shadow-lg rounded-xl p-8">
         <button
           onClick={() => router.push('/01-choice-prefectures')}

--- a/app/02-community-board/[pref]/post/[id]/page.tsx
+++ b/app/02-community-board/[pref]/post/[id]/page.tsx
@@ -39,14 +39,14 @@ export default function PostDetailPage() {
 
   if (!post) {
     return (
-      <div className="max-w-4xl mx-auto py-8">
+      <div className="py-8">
         <div className="bg-white shadow-lg rounded-xl p-8 text-center">読み込み中...</div>
       </div>
     )
   }
 
   return (
-    <div className="max-w-4xl mx-auto py-8">
+    <div className="py-8">
       <div className="bg-white shadow-lg rounded-xl p-8">
         <button
           onClick={() => router.push(`/02-community-board/${pref}`)}


### PR DESCRIPTION
## Summary
- remove `max-w` and `mx-auto` wrappers so main content spans full width
- widen community board pages and forms for consistent layout

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a0976ec0c483278cba548c42a08de3