### PR TITLE
Improve mail button clarity on board list

### DIFF
--- a/app/02-community-board/[pref]/page.tsx
+++ b/app/02-community-board/[pref]/page.tsx
@@ -103,10 +103,11 @@ export default function PostsListPage() {
                     onClick={() =>
                       router.push(`/02-community-board/${pref}/03-mail/${post.id}`)
                     }
-                    className="text-blue-500 hover:text-blue-700 text-2xl"
+                    className="flex items-center px-3 py-1 bg-blue-100 hover:bg-blue-200 text-blue-700 rounded-full text-sm"
                     aria-label="メール送信"
                   >
-                    📧
+                    <span className="mr-1">📧</span>
+                    <span>メールする</span>
                   </button>
                 </div>
 


### PR DESCRIPTION
## Summary
- make the email action button on the community board list more intuitive with text and icon

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a17442699c832799ecb4a5214aa0e6