### PR TITLE
Adjust mobile font sizes

### DIFF
--- a/app/01-choice-prefectures/page.tsx
+++ b/app/01-choice-prefectures/page.tsx
@@ -62,14 +62,14 @@ export default function ChoicePrefecturesPage() {
     <div>
       <div className="bg-white shadow-lg rounded-xl p-8">
         <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold text-blue-700 mb-4">
+          <h1 className="text-3xl md:text-4xl font-bold text-blue-700 mb-4">
             Boys Matching
           </h1>
-          <p className="text-lg text-gray-700">
+          <p className="text-base md:text-lg text-gray-700">
             当サイトはゲイの出会いを目的としています。皆様に素敵な出会いがありますように
           </p>
         </div>
-        <h2 className="text-3xl font-bold text-blue-700 mb-8 text-center">
+        <h2 className="text-2xl md:text-3xl font-bold text-blue-700 mb-8 text-center">
           都道府県を選択してください
         </h2>
 
@@ -108,7 +108,7 @@ export default function ChoicePrefecturesPage() {
         <div className="hidden md:block">
           {REGIONS.map(region => (
             <section key={region.name} className="mb-8">
-              <h3 className="text-2xl font-semibold text-blue-600 mb-4">
+              <h3 className="text-xl md:text-2xl font-semibold text-blue-600 mb-4">
                 {region.name}
               </h3>
               <ul className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4">

--- a/app/02-community-board/[pref]/01-new/page.tsx
+++ b/app/02-community-board/[pref]/01-new/page.tsx
@@ -49,7 +49,7 @@ export default function NewPostPage() {
 
   return (
     <div className="p-6">
-      <h1 className="text-2xl font-semibold mb-4 text-gray-800">
+      <h1 className="text-xl md:text-2xl font-semibold mb-4 text-gray-800">
         「{decodedPref}」に新規投稿
       </h1>
       <form onSubmit={handleSubmit} className="space-y-4">

--- a/app/02-community-board/[pref]/02-delete/[id]/page.tsx
+++ b/app/02-community-board/[pref]/02-delete/[id]/page.tsx
@@ -40,7 +40,7 @@ export default function DeletePostPage() {
 
   return (
     <main className="p-6 bg-white shadow-lg rounded-xl">
-      <h1 className="text-2xl font-semibold mb-4">
+      <h1 className="text-xl md:text-2xl font-semibold mb-4">
         「{decodedPref}」の投稿削除
       </h1>
       <form onSubmit={handleDelete} className="space-y-4">

--- a/app/02-community-board/[pref]/03-mail/[id]/page.tsx
+++ b/app/02-community-board/[pref]/03-mail/[id]/page.tsx
@@ -82,7 +82,7 @@ export default function MailPage() {
 
   return (
     <main className="p-6 bg-white shadow-lg rounded-xl">
-      <h1 className="text-2xl font-semibold mb-4 text-gray-800">
+      <h1 className="text-xl md:text-2xl font-semibold mb-4 text-gray-800">
         メール送信
       </h1>
       <form onSubmit={handleSend} className="space-y-4">

--- a/app/02-community-board/[pref]/page.tsx
+++ b/app/02-community-board/[pref]/page.tsx
@@ -68,7 +68,7 @@ export default function PostsListPage() {
           ← 都道府県を選び直す
         </button>
 
-        <h1 className="text-3xl font-bold text-blue-700 mb-6 text-center">
+        <h1 className="text-2xl md:text-3xl font-bold text-blue-700 mb-6 text-center">
           {decodedPref} の掲示板
         </h1>
 
@@ -137,7 +137,7 @@ export default function PostsListPage() {
                   className="border border-gray-200 rounded-lg p-6 bg-gray-50 hover:bg-gray-100 transition"
                 >
                   <div className="flex justify-between items-start mb-3">
-                    <h2 className="text-xl font-semibold text-blue-800">
+                    <h2 className="text-lg sm:text-xl font-semibold text-blue-800">
                       {post.title}
                     </h2>
                     <button
@@ -203,7 +203,7 @@ export default function PostsListPage() {
                     }
                     className="w-full flex justify-between items-start hover:underline text-left"
                   >
-                    <span className="text-blue-800">{post.title}</span>
+                    <span className="text-sm sm:text-base text-blue-800">{post.title}</span>
                     <span className="ml-4 text-sm text-gray-600 text-right">
                       {post.name || '匿名'}
                       {post.profile ? ` (${post.profile})` : ''}

--- a/app/02-community-board/[pref]/post/[id]/page.tsx
+++ b/app/02-community-board/[pref]/post/[id]/page.tsx
@@ -55,7 +55,7 @@ export default function PostDetailPage() {
           ← 投稿一覧に戻る
         </button>
 
-        <h1 className="text-2xl font-bold text-blue-700 mb-4">{post.title}</h1>
+        <h1 className="text-xl md:text-2xl font-bold text-blue-700 mb-4">{post.title}</h1>
         <div className="text-sm text-gray-600 mb-4">
           {post.name || '匿名'} &middot; {new Date(post.insert_datetime).toLocaleString()}
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,4 +16,11 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+  font-size: 16px;
+}
+
+@media (max-width: 430px) {
+  body {
+    font-size: 14px;
+  }
 }


### PR DESCRIPTION
## Summary
- Use smaller headings and responsive text classes for mobile pages
- Reduce base font size on narrow screens for better readability

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a2992a089c8327afd00dd2e67c323f