### PR TITLE
feat: add messaging handles to post views

### DIFF
--- a/app/02-community-board/[pref]/page.tsx
+++ b/app/02-community-board/[pref]/page.tsx
@@ -165,6 +165,18 @@ export default function PostsListPage() {
 
                   <p className="text-gray-800 whitespace-pre-wrap">{post.content}</p>
 
+                  {post.line_id && (
+                    <p className="text-gray-800 mt-2">LINE ID: {post.line_id}</p>
+                  )}
+                  {post.kakao_id && (
+                    <p className="text-gray-800 mt-1">Kakao ID: {post.kakao_id}</p>
+                  )}
+                  {post.free && (
+                    <p className="text-gray-800 whitespace-pre-wrap mt-1">
+                      フリーテキスト: {post.free}
+                    </p>
+                  )}
+
                   <div className="mt-4 flex justify-end">
                     <button
                       onClick={() =>

--- a/app/02-community-board/[pref]/post/[id]/page.tsx
+++ b/app/02-community-board/[pref]/post/[id]/page.tsx
@@ -70,7 +70,9 @@ export default function PostDetailPage() {
           <p className="text-gray-800 mb-1">Kakao ID: {post.kakao_id}</p>
         )}
         {post.free && (
-          <p className="text-gray-800 whitespace-pre-wrap">{post.free}</p>
+          <p className="text-gray-800 whitespace-pre-wrap">
+            フリーテキスト: {post.free}
+          </p>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- show LINE ID, Kakao ID, and free text in post list view
- label free text on post detail view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a29e57d21483279c3aee5c99f9d50d