### PR TITLE
Improve mail error diagnostics

### DIFF
--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -15,7 +15,9 @@ export async function POST(request: Request) {
     const errorMessage =
       err instanceof Error
         ? err.message
-        : 'メール送信中に予期しないエラーが発生しました'
+        : typeof err === 'object' && err && 'message' in err
+          ? String((err as { message?: unknown }).message)
+          : 'メール送信中に予期しないエラーが発生しました'
     return NextResponse.json({ error: errorMessage }, { status: 500 })
   }
 }

--- a/lib/mailClient.ts
+++ b/lib/mailClient.ts
@@ -16,14 +16,22 @@ export async function sendMail({ from, to, subject, body }: SendParams) {
     throw new Error('MAIL_PROVIDER が mailersend に設定されていません')
   }
 
+  if (!process.env.MAILERSEND_API_KEY) {
+    throw new Error('MAILERSEND_API_KEY が設定されていません')
+  }
+
+  if (!process.env.MAILERSEND_FROM_EMAIL || !process.env.MAILERSEND_FROM_NAME) {
+    throw new Error('MAILERSEND_FROM_EMAIL または MAILERSEND_FROM_NAME が設定されていません')
+  }
+
   const ms = new MailerSend({
-    apiKey: process.env.MAILERSEND_API_KEY!,
+    apiKey: process.env.MAILERSEND_API_KEY,
   })
 
   // 送信元（システム既定）
   const sender = new Sender(
-    process.env.MAILERSEND_FROM_EMAIL!,
-    process.env.MAILERSEND_FROM_NAME!,
+    process.env.MAILERSEND_FROM_EMAIL,
+    process.env.MAILERSEND_FROM_NAME,
   )
 
   // 宛先


### PR DESCRIPTION
## Summary
- validate MailerSend environment variables before attempting to send mail
- surface detailed error messages from mail API failures

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbd53c11c08327beeee59c01706fa2