### PR TITLE
Ensure Reply-To uses DB email

### DIFF
--- a/app/02-community-board/[pref]/03-mail/[id]/page.tsx
+++ b/app/02-community-board/[pref]/03-mail/[id]/page.tsx
@@ -21,7 +21,6 @@ export default function MailPage() {
   const router = useRouter()
 
   const [maskedEmail, setMaskedEmail] = useState('Loading...')
-  const [realEmail, setRealEmail]     = useState('')
   const [fromEmail, setFromEmail]     = useState('')
   const [subject, setSubject]         = useState('')
   const [body, setBody]               = useState('')
@@ -38,7 +37,6 @@ export default function MailPage() {
         if (error || !data?.email) {
           setMaskedEmail('不明')
         } else {
-          setRealEmail(data.email)
           setMaskedEmail(maskEmail(data.email))
         }
       })
@@ -64,7 +62,7 @@ export default function MailPage() {
       const res = await fetch('/api/send-email', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ from: fromEmail, to: realEmail, subject, body })
+        body: JSON.stringify({ from: fromEmail, subject, body, postId })
       })
       const json = await res.json()
       if (!res.ok) throw new Error(json.error || '送信に失敗しました')


### PR DESCRIPTION
## Summary
- fetch recipient email from Supabase in `/api/send-email` using provided `postId`
- update mail page to send `postId` instead of masked email

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbd70b46d88327b0a4e5b52972d3de