### PR TITLE
Ensure Reply-To uses DB email

### DIFF
--- a/app/02-community-board/[pref]/03-mail/[id]/page.tsx
+++ b/app/02-community-board/[pref]/03-mail/[id]/page.tsx
@@ -21,7 +21,6 @@ export default function MailPage() {
   const router = useRouter()
 
   const [maskedEmail, setMaskedEmail] = useState('Loading...')
-  const [realEmail, setRealEmail]     = useState('')
   const [fromEmail, setFromEmail]     = useState('')
   const [subject, setSubject]         = useState('')
   const [body, setBody]               = useState('')
@@ -38,7 +37,6 @@ export default function MailPage() {
         if (error || !data?.email) {
           setMaskedEmail('不明')
         } else {
-          setRealEmail(data.email)
           setMaskedEmail(maskEmail(data.email))
         }
       })
@@ -64,7 +62,7 @@ export default function MailPage() {
       const res = await fetch('/api/send-email', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ from: fromEmail, to: realEmail, subject, body })
+        body: JSON.stringify({ from: fromEmail, subject, body, postId })
       })
       const json = await res.json()
       if (!res.ok) throw new Error(json.error || '送信に失敗しました')

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -2,13 +2,30 @@
 
 import { NextResponse } from 'next/server'
 import { sendMail } from '../../../lib/mailClient'
+import { supabase } from '../../../lib/supabaseClient'
 
 export async function POST(request: Request) {
-  const { from, to, subject, body } = await request.json()
-  console.log('[send-email]', { from, to, subject, body })
+  const { from, subject, body, postId } = await request.json()
+  console.log('[send-email]', { from, postId, subject, body })
+
+  const { data, error } = await supabase
+    .from('TBL_T_POSTS')
+    .select('email')
+    .eq('id', postId)
+    .single()
+
+  if (error || !data?.email) {
+    console.error('Recipient email fetch error:', error)
+    return NextResponse.json(
+      { error: '宛先メールアドレスが取得できませんでした' },
+      { status: 400 }
+    )
+  }
+
+  console.log('[send-email] resolved', { to: data.email })
 
   try {
-    await sendMail({ from, to, subject, body })
+    await sendMail({ from, to: data.email, subject, body })
     return NextResponse.json({ success: true })
   } catch (err: unknown) {
     console.error('Mail send error:', err)

--- a/lib/mailClient.ts
+++ b/lib/mailClient.ts
@@ -1,7 +1,5 @@
 // lib/mailClient.ts
 
-console.log('📨 MAILERSEND_API_KEY:', process.env.MAILERSEND_API_KEY?.slice(0,10) + '…')
-
 import { MailerSend, EmailParams, Sender, Recipient } from 'mailersend'
 
 type SendParams = {
@@ -12,6 +10,14 @@ type SendParams = {
 }
 
 export async function sendMail({ from, to, subject, body }: SendParams) {
+  console.log('[mailClient] config', {
+    MAIL_PROVIDER: process.env.MAIL_PROVIDER,
+    MAILERSEND_API_KEY: process.env.MAILERSEND_API_KEY?.slice(0, 10) + '…',
+    MAILERSEND_FROM_EMAIL: process.env.MAILERSEND_FROM_EMAIL,
+    MAILERSEND_FROM_NAME: process.env.MAILERSEND_FROM_NAME,
+    params: { from, to, subject, body },
+  })
+
   if (process.env.MAIL_PROVIDER !== 'mailersend') {
     throw new Error('MAIL_PROVIDER が mailersend に設定されていません')
   }


### PR DESCRIPTION
## Summary
- fetch recipient email from Supabase in `/api/send-email` using provided `postId`
- update mail page to send `postId` instead of masked email
- log mail configuration values and resolved recipient for debugging

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bbd70b46d88327b0a4e5b52972d3de