### PR TITLE
refactor: remove mail credentials from source code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 MAIL_PROVIDER=mailersend
-MAILERSEND_API_KEY=mlsn.4258854a180bbc7254776cfa7cbbd40f0d96eccd7798b0532494a098da199221
-MAILERSEND_FROM_EMAIL=noreply@boysmatching.com
-MAILERSEND_FROM_NAME=BoysMatchingBSS
+# Replace with your MailerSend API key
+MAILERSEND_API_KEY=YOUR_MAILERSEND_API_KEY
+# Replace with the email address used to send messages
+MAILERSEND_FROM_EMAIL=your-from-email@example.com
+# Replace with the sender name used in emails
+MAILERSEND_FROM_NAME=YourSenderName

--- a/app/api/send-email/route.ts
+++ b/app/api/send-email/route.ts
@@ -29,9 +29,6 @@ export async function POST(request: Request) {
   } catch (err: unknown) {
     console.error('Mail send error:', err, {
       MAIL_PROVIDER: process.env.MAIL_PROVIDER,
-      MAILERSEND_API_KEY: process.env.MAILERSEND_API_KEY,
-      MAILERSEND_FROM_EMAIL: process.env.MAILERSEND_FROM_EMAIL,
-      MAILERSEND_FROM_NAME: process.env.MAILERSEND_FROM_NAME,
     })
     const errorMessage =
       err instanceof Error

--- a/lib/mailClient.ts
+++ b/lib/mailClient.ts
@@ -9,17 +9,7 @@ type SendParams = {
   replyTo?: string
 }
 
-function logMailSettings() {
-  console.log('[mailClient:config]', {
-    MAIL_PROVIDER: process.env.MAIL_PROVIDER,
-    MAILERSEND_API_KEY: process.env.MAILERSEND_API_KEY,
-    MAILERSEND_FROM_EMAIL: process.env.MAILERSEND_FROM_EMAIL,
-    MAILERSEND_FROM_NAME: process.env.MAILERSEND_FROM_NAME,
-  })
-}
-
 export async function sendMail({ to, subject, body, replyTo }: SendParams) {
-  logMailSettings()
   console.log('[mailClient:params]', { to, subject, body, replyTo })
   if (process.env.MAIL_PROVIDER !== 'mailersend') {
     throw new Error('MAIL_PROVIDER が mailersend に設定されていません')


### PR DESCRIPTION
## Summary
- use environment variables for MailerSend configuration
- remove logging of sensitive email credentials
- document mail settings in `.env.example`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6700b0e6c83279ded6ece08d039bd