### PR TITLE
feat: subdivide Tokyo area options

### DIFF
--- a/app/01-choice-prefectures/page.tsx
+++ b/app/01-choice-prefectures/page.tsx
@@ -24,7 +24,7 @@ const REGIONS = [
   },
   {
     name: '東京',
-    prefectures: ['東京都'],
+    prefectures: ['池袋', '新宿', '渋谷/品川', '都心', '区東部', '都下'],
   },
   {
     name: '関東',


### PR DESCRIPTION
## Summary
- split Tokyo into Ikebukuro, Shinjuku, Shibuya/Shinagawa, central, eastern wards, and outer areas on the area selection screen

## Testing
- `npm test` (fails: Missing script: test)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c7a0020a908327a30411a0d700b89c